### PR TITLE
Adds support for not collapsing immediately

### DIFF
--- a/js/jQuery.collapsible.js
+++ b/js/jQuery.collapsible.js
@@ -6,7 +6,10 @@
  * licensed under MIT (filamentgroup.com/examples/mit-license.txt)
  * --------------------------------------------------------------------
  */
-$.fn.collapsible = function(collapse = true){
+$.fn.collapsible = function(collapse){
+	if (collapse == undefined)
+		collapse = true;
+
 	return $(this).each(function(){
 
 		//define

--- a/js/jQuery.collapsible.js
+++ b/js/jQuery.collapsible.js
@@ -2,31 +2,31 @@
  * --------------------------------------------------------------------
  * jQuery collapsible plugin
  * Author: Scott Jehl, scott@filamentgroup.com
- * Copyright (c) 2009 Filament Group 
+ * Copyright (c) 2009 Filament Group
  * licensed under MIT (filamentgroup.com/examples/mit-license.txt)
  * --------------------------------------------------------------------
  */
 $.fn.collapsible = function(collapse = true){
 	return $(this).each(function(){
-	
+
 		//define
 		var collapsibleHeading = $(this);
 		var collapsibleContent = collapsibleHeading.next();
-		
+
 		//modify markup & attributes
 		collapsibleHeading.addClass('collapsible-heading')
 			.prepend('<span class="collapsible-heading-status"></span>')
 			.wrapInner('<a href="#" class="collapsible-heading-toggle"></a>');
-			
+
 		collapsibleContent.addClass('collapsible-content');
-		
+
 		//events
-		collapsibleHeading	
+		collapsibleHeading
 			.bind('collapse', function(){
 				$(this)
 					.addClass('collapsible-heading-collapsed')
 					.find('.collapsible-heading-status').text('Show ');
-										
+
 				collapsibleContent.slideUp(function(){
 					$(this).addClass('collapsible-content-collapsed').removeAttr('style').attr('aria-hidden',true);
 				});
@@ -35,18 +35,18 @@ $.fn.collapsible = function(collapse = true){
 				$(this)
 					.removeClass('collapsible-heading-collapsed')
 					.find('.collapsible-heading-status').text('Hide ');
-										
+
 				collapsibleContent
 					.slideDown(function(){
 						$(this).removeClass('collapsible-content-collapsed').removeAttr('style').attr('aria-hidden',false);
 					});
 			})
-			.click(function(){ 
+			.click(function(){
 				if( $(this).is('.collapsible-heading-collapsed') ){
-					$(this).trigger('expand'); 
-				}	
+					$(this).trigger('expand');
+				}
 				else {
-					$(this).trigger('collapse'); 
+					$(this).trigger('collapse');
 				}
 				return false;
 			});
@@ -54,5 +54,5 @@ $.fn.collapsible = function(collapse = true){
 		// if we should start collapsed, collapse now.
 		if (collapse)
 			collapsibleHeading.trigger('collapse');
-	});	
-};	
+	});
+};

--- a/js/jQuery.collapsible.js
+++ b/js/jQuery.collapsible.js
@@ -6,7 +6,7 @@
  * licensed under MIT (filamentgroup.com/examples/mit-license.txt)
  * --------------------------------------------------------------------
  */
-$.fn.collapsible = function(){
+$.fn.collapsible = function(collapse = true){
 	return $(this).each(function(){
 	
 		//define
@@ -49,7 +49,10 @@ $.fn.collapsible = function(){
 					$(this).trigger('collapse'); 
 				}
 				return false;
-			})
-			.trigger('collapse');
+			});
+
+		// if we should start collapsed, collapse now.
+		if (collapse)
+			collapsibleHeading.trigger('collapse');
 	});	
 };	


### PR DESCRIPTION
We have a use case for making things collapsible, but starting with the item uncollapsed. This pull request allows one to pass a collapse=false argument, which causes .trigger('collapse') not to be called.
